### PR TITLE
[Test] Fix: mute parameter is not passed on to the command

### DIFF
--- a/custom_components/hass_agent/media_player.py
+++ b/custom_components/hass_agent/media_player.py
@@ -249,7 +249,7 @@ class HassAgentMediaPlayerDevice(MediaPlayerEntity):
 
     async def async_mute_volume(self, mute):
         """Mute the volume"""
-        await self._send_command("mute")
+        await self._send_command(mute)
 
     async def async_media_play(self):
         """Send play command"""


### PR DESCRIPTION
Mute parameter is now properly passed on to the sent command.